### PR TITLE
Fix crew config and expand docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # ihome-agents
+
+This repository hosts the **ResearchStocks** crew built with [crewAI](https://crewai.com). The agents gather market data, analyse fundamentals and technicals and produce a daily market brief.
+
+## Quick start
+
+1. Install Python 3.10 or newer.
+2. Install [uv](https://docs.astral.sh/uv/) and project dependencies:
+   ```bash
+   pip install uv
+   crewai install
+   ```
+3. Create a `.env` file with your API keys (`OPENAI_API_KEY`, `NEWSAPI_KEY`, `POLYGON_KEY`, etc.).
+4. (Optional) set `CACHE_DIR` to reuse API responses across runs.
+5. Run the crew:
+   ```bash
+   crewai run
+   ```
+
+See `research_stocks/README.md` for full documentation and customisation options.

--- a/research_stocks/README.md
+++ b/research_stocks/README.md
@@ -37,6 +37,13 @@ $ crewai run
 
 This command initializes the research_stocks Crew, assembling the agents and assigning them tasks as defined in your configuration.
 
+### Cost controls
+
+The crew uses multiple LLM models to keep expenses in check. Data gathering and
+valuation run on GPT‑3.5, while analysis and report writing rely on GPT‑4 with
+token limits. Setting the `CACHE_DIR` environment variable enables API response
+caching for repeated runs.
+
 This example, unmodified, will run the create a `report.md` file with the output of a research on LLMs in the root folder.
 
 ## Understanding Your Crew

--- a/research_stocks/src/research_stocks/config/tasks.yaml
+++ b/research_stocks/src/research_stocks/config/tasks.yaml
@@ -47,3 +47,16 @@ compose_report:
     daily_market_brief.md file path and Slack message ID confirming post.
   output_file: daily_market_brief.md
   agent: report_composer_agent
+
+compose_report_followup:
+  description: >
+    Generate the end‑of‑morning market briefing in clear, blog‑style
+    English. Include: (1) top political headlines; (2) ETF performance with
+    drivers; (3) intraday outlook for ~5 equities; (4) global macro / geo‑
+    political events; (5) sentiment & volatility snapshot. Format in
+    markdown with headings, bold tickers, and a timestamp footer. Save to
+    daily_market_brief.md and post to Slack #market‑briefings.
+  expected_output: >
+    daily_market_brief.md file path and Slack message ID confirming post.
+  output_file: daily_market_brief.md
+  agent: report_composer_agent


### PR DESCRIPTION
## Summary
- import `os` in crew initialization
- add `compose_report_followup` task configuration
- document setup instructions in root README
- tune LLM selection and caching for lower costs

## Testing
- `python -m py_compile research_stocks/src/research_stocks/crew.py research_stocks/src/research_stocks/tools/market_data_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e7433a2c8326afd3c2b7fa37db4e