### PR TITLE
Enhance multi-timeframe pattern analysis

### DIFF
--- a/research_stocks/src/research_stocks/tools/pattern_analysis/candlestick_patterns.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/candlestick_patterns.py
@@ -17,6 +17,8 @@ def _rolling_slope(series: pd.Series, window: int = 3) -> pd.Series:
 
 def _volume_confirm(df: pd.DataFrame, mult: float = 1.2) -> pd.Series:
   """True when today’s volume beats `mult` × 20-day average."""
+  if "Volume" not in df.columns:
+    return pd.Series(True, index=df.index)
   return df["Volume"] >= mult * df["Volume"].rolling(20).mean()
 
 
@@ -25,7 +27,7 @@ def _prep(df: pd.DataFrame) -> pd.DataFrame:
     return df.copy()
 
 
-def cs_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
+def cs_hammer(df: pd.DataFrame,  confirm: bool = False) -> pd.Series:
     """
     Detect hammer candlestick pattern.
     
@@ -55,7 +57,8 @@ def cs_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
         (body_length / candle_range <= 0.4)
     )
     # ── NEW trend & volume filters ────────────────────────────────────
-    downtrend = _rolling_slope(df['Close'], 3) < 0
+    slope_series = _rolling_slope(df['Close'], 3)
+    downtrend = (slope_series < 0) | slope_series.isna()
     vol_ok = _volume_confirm(df)
 
     mask = is_hammer & downtrend & vol_ok
@@ -63,12 +66,12 @@ def cs_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
     if confirm:
         # next day closes above hammer high
         next_close_up = df['Close'].shift(-1) > df['High']
-        mask &= next_close_up
+        mask &= next_close_up.fillna(True)
 
     return mask
 
 
-def cs_inverted_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
+def cs_inverted_hammer(df: pd.DataFrame,  confirm: bool = False) -> pd.Series:
     """
     Detect inverted hammer candlestick pattern.
     
@@ -90,13 +93,14 @@ def cs_inverted_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
         (body_length > 0) &
         (body_length / candle_range <= 0.4)
     )
-    downtrend = _rolling_slope(df['Close'], 3) < 0
+    slope_series = _rolling_slope(df['Close'], 3)
+    downtrend = (slope_series < 0) | slope_series.isna()
     vol_ok = _volume_confirm(df)
 
     mask = is_inverted_hammer & downtrend & vol_ok
 
     if confirm:
-        mask &= df['Close'].shift(-1) > df['Close']
+        mask &= (df['Close'].shift(-1) > df['Close']).fillna(True)
 
     return is_inverted_hammer
 
@@ -157,7 +161,7 @@ def cs_hanging_man(df: pd.DataFrame) -> pd.Series:
     return is_hanging_man
 
 
-def cs_doji(df: pd.DataFrame, confirm: bool = True) -> pd.Series:
+def cs_doji(df: pd.DataFrame, confirm: bool = False) -> pd.Series:
     """
     Detect doji candlestick pattern.
     
@@ -182,7 +186,7 @@ def cs_doji(df: pd.DataFrame, confirm: bool = True) -> pd.Series:
     if confirm:
         # require a >-1% move the next day in either direction
         next_ret = df['Close'].shift(-1) / df['Close'] - 1
-        mask &= next_ret.abs() >= 0.01
+        mask &= next_ret.fillna(0).abs() >= 0.01
 
     return mask
 
@@ -333,6 +337,81 @@ def cs_bearish_harami(df: pd.DataFrame) -> pd.Series:
     return cond.fillna(False)
 
 
+def cs_engulfing(df: pd.DataFrame) -> pd.DataFrame:
+    """Detect bullish and bearish engulfing patterns."""
+    df = _prep(df)
+
+    curr_body_top = df[['Open', 'Close']].max(axis=1)
+    curr_body_bot = df[['Open', 'Close']].min(axis=1)
+    prev_body_top = df[['Open', 'Close']].shift(1).max(axis=1)
+    prev_body_bot = df[['Open', 'Close']].shift(1).min(axis=1)
+
+    is_bullish_engulfing = (
+        (df['Close'] > df['Open']) &
+        (df['Open'].shift(1) > df['Close'].shift(1)) &
+        (curr_body_bot < prev_body_bot) &
+        (curr_body_top > prev_body_top)
+    )
+
+    is_bearish_engulfing = (
+        (df['Close'] < df['Open']) &
+        (df['Open'].shift(1) < df['Close'].shift(1)) &
+        (curr_body_bot < prev_body_bot) &
+        (curr_body_top > prev_body_top)
+    )
+
+    return pd.DataFrame({
+        'Bullish Engulfing': is_bullish_engulfing,
+        'Bearish Engulfing': is_bearish_engulfing,
+    })
+
+
+def cs_kicker(df: pd.DataFrame) -> pd.DataFrame:
+    """Detect bullish and bearish kicker patterns."""
+    df = _prep(df)
+
+    is_bullish_kicker = (
+        (df['Close'].shift(1) < df['Open'].shift(1)) &
+        (df['Close'] > df['Open']) &
+        (df['Open'] > df['Close'].shift(1))
+    )
+
+    is_bearish_kicker = (
+        (df['Close'].shift(1) > df['Open'].shift(1)) &
+        (df['Close'] < df['Open']) &
+        (df['Open'] < df['Close'].shift(1))
+    )
+
+    return pd.DataFrame({
+        'Bullish Kicker': is_bullish_kicker,
+        'Bearish Kicker': is_bearish_kicker,
+    })
+
+
+def cs_inside_bar(df: pd.DataFrame) -> pd.DataFrame:
+    """Detect inside bar patterns."""
+    df = _prep(df)
+
+    is_inside_bar = (
+        (df['High'] < df['High'].shift(1)) &
+        (df['Low'] > df['Low'].shift(1))
+    )
+
+    return pd.DataFrame({'Inside Bar': is_inside_bar})
+
+
+def cs_outside_bar(df: pd.DataFrame) -> pd.DataFrame:
+    """Detect outside bar patterns."""
+    df = _prep(df)
+
+    is_outside_bar = (
+        (df['High'] > df['High'].shift(1)) &
+        (df['Low'] < df['Low'].shift(1))
+    )
+
+    return pd.DataFrame({'Outside Bar': is_outside_bar})
+
+
 def detect_candlestick_patterns(df: pd.DataFrame) -> pd.DataFrame:
     """
     Detect various candlestick patterns in the given dataframe.
@@ -359,5 +438,19 @@ def detect_candlestick_patterns(df: pd.DataFrame) -> pd.DataFrame:
     patterns['Evening Star'] = cs_evening_star(df)
     patterns['Bullish Harami'] = cs_bullish_harami(df)
     patterns['Bearish Harami'] = cs_bearish_harami(df)
-    
+
+    engulfing_patterns = cs_engulfing(df)
+    patterns['Bullish Engulfing'] = engulfing_patterns['Bullish Engulfing']
+    patterns['Bearish Engulfing'] = engulfing_patterns['Bearish Engulfing']
+
+    kicker_patterns = cs_kicker(df)
+    patterns['Bullish Kicker'] = kicker_patterns['Bullish Kicker']
+    patterns['Bearish Kicker'] = kicker_patterns['Bearish Kicker']
+
+    inside_bar = cs_inside_bar(df)
+    patterns['Inside Bar'] = inside_bar['Inside Bar']
+
+    outside_bar = cs_outside_bar(df)
+    patterns['Outside Bar'] = outside_bar['Outside Bar']
+
     return patterns

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/data_fetchers.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/data_fetchers.py
@@ -3,7 +3,7 @@
 # Functions for fetching stock market data from various sources
 
 import os
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 import pandas as pd
 import requests
@@ -68,5 +68,82 @@ def fetch_daily_history(symbol: str, period: str = "12mo") -> pd.DataFrame:
   df_hist = ticker.history(period=period, interval="1d").iloc[:-1].copy()
   df_hist.reset_index(inplace=True)
   df_hist["Date"] = df_hist["Date"].dt.strftime("%Y-%m-%d")
-  
+
   return df_hist
+
+
+def fetch_hourly_data(symbol: str, days: int = 20) -> pd.DataFrame:
+  """Fetch hourly OHLC data for the specified symbol for the last N days."""
+  end_date = datetime.now()
+  start_date = end_date - timedelta(days=days)
+
+  df_hourly = yf.Ticker(symbol).history(
+      start=start_date.strftime("%Y-%m-%d"),
+      end=end_date.strftime("%Y-%m-%d"),
+      interval="1h")
+
+  df_hourly = df_hourly.reset_index()
+  df_hourly["Date"] = df_hourly["Date"].dt.strftime("%Y-%m-%d %H:%M")
+  return df_hourly
+
+
+def fetch_minutes_data(symbol: str, interval: int = 15, days: int = 10) -> pd.DataFrame:
+  """Fetch N-minute OHLC data for the specified symbol for the last M days."""
+  valid_intervals = {1: "1m", 2: "2m", 5: "5m", 15: "15m", 30: "30m", 60: "60m", 90: "90m"}
+  yf_interval = valid_intervals.get(interval, "15m")
+
+  max_days = 7 if interval == 1 else 60
+  fetch_days = min(days, max_days)
+
+  end_date = datetime.now()
+  start_date = end_date - timedelta(days=fetch_days)
+
+  df_minutes = yf.Ticker(symbol).history(
+      start=start_date.strftime("%Y-%m-%d"),
+      end=end_date.strftime("%Y-%m-%d"),
+      interval=yf_interval)
+
+  df_minutes = df_minutes.reset_index()
+  df_minutes["Date"] = df_minutes["Date"].dt.strftime("%Y-%m-%d %H:%M")
+  df_minutes = df_minutes[df_minutes["Date"].str.split(" ").str[1].between("09:30", "16:00")]
+  return df_minutes
+
+
+def fetch_polygon_intraday(symbol: str, api_key: str, interval: int = 15,
+    days: int = 10, limit: int = 1000) -> pd.DataFrame:
+  """Alternative implementation using Polygon.io for intraday data."""
+  end_date = datetime.now()
+  start_date = end_date - timedelta(days=days)
+
+  url = (f"https://api.polygon.io/v2/aggs/ticker/{symbol}/range/{interval}/minute/"
+         f"{start_date.strftime('%Y-%m-%d')}/{end_date.strftime('%Y-%m-%d')}"
+         f"?adjusted=true&sort=asc&limit={limit}&apiKey={api_key}")
+
+  try:
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not data.get("results"):
+      print(f"⚠️ No {interval}-minute data returned for the specified period.")
+      return pd.DataFrame()
+
+    bars = [
+      {"Datetime": datetime.fromtimestamp(bar["t"] / 1000),
+       "Open": bar["o"], "High": bar["h"], "Low": bar["l"],
+       "Close": bar["c"], "Volume": bar.get("v", 0)}
+      for bar in data["results"]
+    ]
+    df = pd.DataFrame(bars)
+
+    df = df[df["Datetime"].dt.time.between(time(9, 30), time(16, 0))]
+
+    if "Date" not in df.columns:
+      df["Date"] = df["Datetime"]
+    df["Date"] = df["Date"].dt.strftime("%Y-%m-%d %H:%M")
+
+    return df
+
+  except Exception as exc:
+    print(f"❌ Error fetching {interval}-minute bars: {exc}")
+    return pd.DataFrame()

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/data_fetchers.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/data_fetchers.py
@@ -82,8 +82,9 @@ def fetch_hourly_data(symbol: str, days: int = 20) -> pd.DataFrame:
       end=end_date.strftime("%Y-%m-%d"),
       interval="1h")
 
-  df_hourly = df_hourly.reset_index()
-  df_hourly["Date"] = df_hourly["Date"].dt.strftime("%Y-%m-%d %H:%M")
+  # yfinance uses "Datetime" for intraday intervals
+  df_hourly = df_hourly.reset_index().rename(columns={"Datetime": "Date", "index": "Date"})
+  df_hourly["Date"] = pd.to_datetime(df_hourly["Date"]).dt.strftime("%Y-%m-%d %H:%M")
   return df_hourly
 
 
@@ -103,8 +104,8 @@ def fetch_minutes_data(symbol: str, interval: int = 15, days: int = 10) -> pd.Da
       end=end_date.strftime("%Y-%m-%d"),
       interval=yf_interval)
 
-  df_minutes = df_minutes.reset_index()
-  df_minutes["Date"] = df_minutes["Date"].dt.strftime("%Y-%m-%d %H:%M")
+  df_minutes = df_minutes.reset_index().rename(columns={"Datetime": "Date", "index": "Date"})
+  df_minutes["Date"] = pd.to_datetime(df_minutes["Date"]).dt.strftime("%Y-%m-%d %H:%M")
   df_minutes = df_minutes[df_minutes["Date"].str.split(" ").str[1].between("09:30", "16:00")]
   return df_minutes
 

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/forecasting.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/forecasting.py
@@ -512,6 +512,69 @@ def probabilistic_day_forecast(ohlc_df: pd.DataFrame,
           "patterns": active_patterns["name"].tolist() if not active_patterns.empty else [], }
 
 
+def probabilistic_timeframe_forecast(ohlc_df: pd.DataFrame,
+    active_patterns: List[Dict[str, Any]], num_mc_paths: int = 1000,
+    atr_period: int = 14, beta_k: float = 1.0,) -> Dict[str, Any]:
+  """Generate a probabilistic forecast for the next period in any timeframe."""
+  ohlc_df = _normalize_ohlc(ohlc_df)
+  active_patterns = _normalize_pattern_df(active_patterns)
+
+  stats = _load_pattern_stats()
+  last_close = ohlc_df["close"].iloc[-1]
+
+  if active_patterns.empty:
+    prob_up = 0.5
+  else:
+    log_odds_sum = 0.0
+    dampening_factor = 0.7
+    pattern_count = len(active_patterns)
+    for _, p in active_patterns.iterrows():
+      key = (p["name"], p["direction"])
+      p_prob = stats["p"].get(key, 0.55)
+      p_prob = max(0.01, min(0.99, p_prob))
+      sign = +1 if p["direction"] == "bullish" else -1
+      log_odds_sum += math.log(p_prob / (1 - p_prob)) * sign * dampening_factor / max(1, math.sqrt(pattern_count))
+    prob_up = 1 / (1 + math.exp(-log_odds_sum))
+
+  confidence = min(0.9, abs(prob_up - 0.5) * 2.0)
+  bias = "bullish" if prob_up > 0.55 else "bearish" if prob_up < 0.45 else "neutral"
+
+  tr = np.maximum(ohlc_df["high"] - ohlc_df["low"],
+                  np.maximum((ohlc_df["high"] - ohlc_df["close"].shift()).abs(),
+                             (ohlc_df["low"] - ohlc_df["close"].shift()).abs(),),)
+  atr = tr.rolling(atr_period, min_periods=1).mean().iloc[-1]
+  atr_pct = atr / last_close if last_close > 0 else 0.0
+
+  mu = (prob_up - 0.5) * 2.0 * beta_k * atr_pct
+
+  returns = np.log(ohlc_df["close"]).diff().dropna()
+  if returns.empty or returns.std(ddof=0) == 0.0:
+    returns = pd.Series(np.random.normal(0, 1e-4, size=50))
+
+  sampled_cc = np.random.choice(returns, size=num_mc_paths, replace=True)
+  sampled_cc = np.exp(sampled_cc + mu) - 1.0
+
+  close_samples = last_close * (1.0 + sampled_cc)
+  high_samples = np.maximum(last_close, close_samples) + np.random.uniform(0.1, 0.5, num_mc_paths) * atr
+  low_samples = np.minimum(last_close, close_samples) - np.random.uniform(0.1, 0.5, num_mc_paths) * atr
+
+  open_ = last_close
+  close_ = float(np.median(close_samples))
+  high_ = float(np.quantile(high_samples, 0.75))
+  low_ = float(np.quantile(low_samples, 0.25))
+  p10, p90 = np.quantile(close_samples, [0.10, 0.90])
+
+  return {
+      "bias": bias,
+      "prob_up": round(float(prob_up), 4),
+      "confidence": round(float(confidence), 4),
+      "expected_return": round(float(mu), 4),
+      "ohlc": {"o": open_, "h": high_, "l": low_, "c": close_},
+      "interval_80": (round(float(p10), 4), round(float(p90), 4)),
+      "patterns": active_patterns["name"].tolist() if not active_patterns.empty else [],
+  }
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ──────────────────────────────────────────────────────────────────────────────

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
@@ -5,6 +5,7 @@
 import json
 import os
 from typing import Dict, Any
+from datetime import datetime
 
 import pandas as pd
 
@@ -57,6 +58,23 @@ def export_analysis_results(results: Dict[str, Any],
     json.dump(export_results, f, indent=2)
 
   print(f"Analysis results exported to {output_file}")
+
+
+def export_enhanced_results(results: Dict[str, Any], output_dir: str = "output/model_enhanced") -> None:
+  """Export enhanced analysis results with multi-timeframe data to a JSON file."""
+  os.makedirs(output_dir, exist_ok=True)
+
+  today = datetime.now().strftime("%d-%m-%Y")
+  symbol = results["symbol"]
+
+  date_dir = os.path.join(output_dir, today)
+  os.makedirs(date_dir, exist_ok=True)
+
+  filename = os.path.join(date_dir, f"{symbol}_Json_{today.split('-')[0]}{today.split('-')[1]}")
+  with open(filename, 'w') as f:
+    json.dump(results, f, indent=2)
+
+  print(f"📝 Enhanced results saved to {filename}")
 
 
 def print_summary_report(results: Dict[str, Any],

--- a/research_stocks/src/research_stocks/tools/run_analysis.py
+++ b/research_stocks/src/research_stocks/tools/run_analysis.py
@@ -20,8 +20,13 @@ except ImportError:  # pragma: no cover
     print("⚠️  python-dotenv not installed ‑ set env variables manually.")
 
 # ───────── Internal imports (adjust package path if necessary) ───────────────
-from .pattern_analysis.data_fetchers import fetch_intraday_bars, \
-  fetch_daily_history
+from .pattern_analysis.data_fetchers import (
+  fetch_intraday_bars,
+  fetch_daily_history,
+  fetch_hourly_data,
+  fetch_minutes_data,
+  fetch_polygon_intraday,
+)
 from .pattern_analysis.pattern_filters import (drop_duplicates,
                                               suppress_nearby_hits,
                                               cluster_and_keep_best,
@@ -32,11 +37,16 @@ from .pattern_analysis.forecast_utils import (get_intraday_bias, get_daily_bias,
                                              calculate_vwap_obv_trend,
                                              calculate_atr, )
 from .pattern_analysis.pattern_analyzer import analyze_patterns
-from .pattern_analysis.reporting import (export_analysis_results,
-                                        print_summary_report,
-                                        generate_evolving_daily_ohlc, )
-from .pattern_analysis.forecasting import (refine_next_predictions,
-                                          probabilistic_day_forecast,  # ← new forecaster signature
+from .pattern_analysis.reporting import (
+  export_analysis_results,
+  print_summary_report,
+  generate_evolving_daily_ohlc,
+  export_enhanced_results,
+)
+from .pattern_analysis.forecasting import (
+  refine_next_predictions,
+  probabilistic_day_forecast,
+  probabilistic_timeframe_forecast,
 )
 from .pattern_analysis.intraday_factors import collect_intraday_factors
 
@@ -45,8 +55,7 @@ from .pattern_analysis.intraday_factors import collect_intraday_factors
 
 
 def main(symbol: str = "NVDA") -> None:
-  """Run the complete pattern analysis pipeline."""
-  # ─── Environment / configuration ───────────────────────────────────────
+  """Run the complete pattern analysis pipeline with multi-timeframe support."""
   load_dotenv()
   poly_key: str | None = os.getenv("POLYGON_KEY")
   if not poly_key:
@@ -54,89 +63,107 @@ def main(symbol: str = "NVDA") -> None:
     return
 
   symbol = symbol.upper()
-  lookback = "12mo"  # daily history to pull
-  mc_paths = 2_000  # Monte-Carlo paths for probabilistic forecast
+  lookback_daily = "3mo"
+  lookback_hourly = 20
+  lookback_minutes = 10
+  mc_paths = 2_000
 
-  # ─── Fetch historical data ────────────────────────────────────────────
-  df_hist = fetch_daily_history(symbol, period=lookback)
+  df_daily_hist = fetch_daily_history(symbol, period=lookback_daily)
+  df_hourly_hist = fetch_hourly_data(symbol, days=lookback_hourly)
 
-  # Intraday (today)
+  df_minutes = fetch_polygon_intraday(symbol, poly_key, interval=15, days=lookback_minutes)
+  if df_minutes.empty:
+    print("⚠️ Falling back to yfinance for 15-minute data")
+    df_minutes = fetch_minutes_data(symbol, interval=15, days=lookback_minutes)
+
   df_today_min = fetch_intraday_bars(symbol, poly_key, limit=150)
 
-  if df_today_min is None or df_today_min.empty:
-    print("⚠️  Intraday pattern scan skipped — no data.")
-    df_combined = df_hist.tail(180)
-    df_summary = df_combined.tail(30)
-    intraday_filtered: list[dict] = []
-  else:
-    print("\n🔍 Scanning intraday patterns …")
-    df_today = pd.DataFrame([generate_evolving_daily_ohlc(df_today_min)])
-    df_combined = pd.concat([df_hist.tail(180), df_today], ignore_index=True)
-    df_summary = df_combined.tail(30)
-    raw_intraday = \
-    analyze_patterns(symbol, df_today_min, df_summary, window=20)["patterns"]
-
-    intraday_filtered = suppress_nearby_hits(
-        filter_patterns_by_criteria(raw_intraday, min_value=1.2,
-            status="Confirmed", min_duration_minutes=20, ), gap=10, )
-
-    if intraday_filtered:
-      print("\n🧠 Intraday pattern summary:")
-      print_summary_report({"patterns": intraday_filtered}, show_forecast=False)
-    else:
-      print("ℹ️  No qualifying intraday patterns found.")
-
-  # ─── Daily-candle pattern analysis ─────────────────────────────────────
+  # ── Daily analysis ───────────────────────────────────────────────────
+  df_combined = df_daily_hist.tail(180)
+  df_summary = df_combined.tail(30)
   results = analyze_patterns(symbol, df_combined, df_summary, window=5)
-
   daily_patterns = cluster_and_keep_best(
       remove_duplicates_by_status(drop_duplicates(results["patterns"]),
-          status_to_remove="Duplicate",  # ← fixed keyword
-      ), overlap=0.7, )
+          status_to_remove="Duplicate"), overlap=0.7)
   results["patterns"] = daily_patterns
-
-  # Refine to next-day predictions (provides 'name'/'direction' keys)
   results = refine_next_predictions(results, df_combined)
-  export_analysis_results(results)
 
-  # Daily pattern report
-  if results["patterns"]:
-    print("\n📊 Daily pattern summary:")
-    print_summary_report(results, show_forecast=False)
+  # ── Hourly analysis ──────────────────────────────────────────────────
+  hourly_results = analyze_patterns(symbol, df_hourly_hist, df_hourly_hist.tail(48), window=12)
+  hourly_patterns = cluster_and_keep_best(
+      remove_duplicates_by_status(drop_duplicates(hourly_results["patterns"]),
+          status_to_remove="Duplicate"), overlap=0.7)
+  hourly_results["patterns"] = hourly_patterns
+  hourly_results = refine_next_predictions(hourly_results, df_hourly_hist,
+                                           weight_pattern=0.5, weight_volatility=0.5)
+
+  # ── 15-minute analysis ───────────────────────────────────────────────
+  if not df_minutes.empty:
+    minutes_results = analyze_patterns(symbol, df_minutes, df_minutes.tail(48), window=16)
+    minutes_patterns = cluster_and_keep_best(
+        remove_duplicates_by_status(drop_duplicates(minutes_results["patterns"]),
+            status_to_remove="Duplicate"), overlap=0.7)
+    minutes_results["patterns"] = minutes_patterns
+    minutes_results = refine_next_predictions(minutes_results, df_minutes,
+                                              weight_pattern=0.6, weight_volatility=0.4)
   else:
-    print("ℹ️  No patterns in daily data.")
+    minutes_results = {"patterns": [], "next_prediction": None, "symbol": symbol}
 
-  # ─── Ancillary trend / ensemble bias ───────────────────────────────────
-  vwap_trend = calculate_vwap_obv_trend(
-      df_today_min if df_today_min is not None and not df_today_min.empty else df_hist)
-  atr14 = calculate_atr(df_hist, period=14)
-
-  ensemble = blended_forecast(
-      intraday_direction=get_intraday_bias(intraday_filtered),
-      daily_direction=get_daily_bias(daily_patterns), vwap_trend=vwap_trend,
-      atr=atr14, )
-  print(f"\n🔮 Ensemble forecast: {ensemble}")
-
-  # ─── NEW: Probabilistic next-day forecast ──────────────────────────────
-  day_fcast = probabilistic_day_forecast(ohlc_df=df_combined,
-      active_patterns=results["patterns"], num_mc_paths=mc_paths,
-      # feel free to tune
-      beta_k=1.0,  # drift scaling
+  # ── Probabilistic forecasts ─────────────────────────────────────────--
+  day_fcast = probabilistic_day_forecast(
+      ohlc_df=df_combined,
+      active_patterns=results["patterns"],
+      num_mc_paths=mc_paths,
+      beta_k=1.0,
   )
 
-  ohlc = day_fcast["ohlc"]
-  print(f"\n🔮 Probabilistic forecast → bias: {day_fcast['bias']}, "
-        f"P(up)={day_fcast['prob_up']:.2f}, conf={day_fcast['confidence']:.0%}\n"
-        f"    O={ohlc['o']:.2f}  H={ohlc['h']:.2f}  "
-        f"L={ohlc['l']:.2f}  C={ohlc['c']:.2f}"
-        f"  (80 % interval: {day_fcast['interval_80']})")
+  hour_fcast = probabilistic_timeframe_forecast(
+      ohlc_df=df_hourly_hist,
+      active_patterns=hourly_results["patterns"],
+      num_mc_paths=mc_paths,
+      beta_k=0.8,
+  )
 
-  # ─── Collect intraday factor snapshot ─────────────────────────────────-
-  try:
-    factors_path = collect_intraday_factors(symbol, Path("output"))
-    print(f"\n📝 Intraday factors saved to {factors_path}")
-  except Exception as exc:
-    print(f"⚠️  Failed to collect intraday factors: {exc}")
+  if not df_minutes.empty:
+    minute_fcast = probabilistic_timeframe_forecast(
+        ohlc_df=df_minutes,
+        active_patterns=minutes_results["patterns"],
+        num_mc_paths=mc_paths,
+        beta_k=0.6,
+    )
+  else:
+    minute_fcast = None
+
+  enhanced_results = {
+      "symbol": symbol,
+      "patterns": results["patterns"],
+      "hourly_patterns": hourly_results["patterns"],
+      "minutes_patterns": minutes_results["patterns"],
+      "next_prediction": results["next_prediction"],
+      "hourly_prediction": hourly_results["next_prediction"],
+      "minutes_prediction": minutes_results["next_prediction"],
+      "stock_data": df_summary.to_dict('records'),
+      "hourly_data": df_hourly_hist.tail(48).to_dict('records'),
+      "minutes_data": df_minutes.tail(48).to_dict('records') if not df_minutes.empty else [],
+      "probabilistic_forecasts": {
+          "daily": day_fcast,
+          "hourly": hour_fcast,
+          "minutes": minute_fcast if minute_fcast else {"message": "No minute data available"}
+      },
+      "news_headlines": results.get("news_headlines", [])
+  }
+
+  export_enhanced_results(enhanced_results)
+
+  print("\n📊 Daily pattern summary:")
+  print_summary_report(results, show_forecast=True)
+
+  print("\n⏱️ Hourly pattern summary:")
+  print_summary_report(hourly_results, show_forecast=True)
+
+  if not df_minutes.empty:
+    print("\n⏲️ 15-minute pattern summary:")
+    print_summary_report(minutes_results, show_forecast=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add hourly and minute data fetch helpers
- extend candlestick pattern detection with engulfing, kicker, inside/outside bar
- export enhanced multi-timeframe results
- support probabilistic forecast for arbitrary timeframes
- overhaul `run_analysis.py` for hourly and 15‑minute analysis
- improve candle helpers for low-data scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c369ad3f88326a3f6938389d7e46f