### PR TITLE
Fix enhanced reporting JSON export

### DIFF
--- a/research_stocks/src/research_stocks/tools/pattern_analysis/candlestick_patterns.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/candlestick_patterns.py
@@ -17,6 +17,8 @@ def _rolling_slope(series: pd.Series, window: int = 3) -> pd.Series:
 
 def _volume_confirm(df: pd.DataFrame, mult: float = 1.2) -> pd.Series:
   """True when today’s volume beats `mult` × 20-day average."""
+  if "Volume" not in df.columns:
+    return pd.Series([True] * len(df), index=df.index)
   return df["Volume"] >= mult * df["Volume"].rolling(20).mean()
 
 
@@ -55,13 +57,15 @@ def cs_hammer(df: pd.DataFrame,  confirm: bool = True) -> pd.Series:
         (body_length / candle_range <= 0.4)
     )
     # ── NEW trend & volume filters ────────────────────────────────────
-    downtrend = _rolling_slope(df['Close'], 3) < 0
+    if len(df) >= 3:
+        downtrend = _rolling_slope(df['Close'], 3) < 0
+    else:
+        downtrend = pd.Series(True, index=df.index)
     vol_ok = _volume_confirm(df)
 
     mask = is_hammer & downtrend & vol_ok
 
-    if confirm:
-        # next day closes above hammer high
+    if confirm and len(df) >= 2:
         next_close_up = df['Close'].shift(-1) > df['High']
         mask &= next_close_up
 
@@ -179,8 +183,7 @@ def cs_doji(df: pd.DataFrame, confirm: bool = True) -> pd.Series:
     vol_ok = _volume_confirm(df)
     mask = is_doji & vol_ok
 
-    if confirm:
-        # require a >-1% move the next day in either direction
+    if confirm and len(df) >= 2:
         next_ret = df['Close'].shift(-1) / df['Close'] - 1
         mask &= next_ret.abs() >= 0.01
 

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
@@ -4,9 +4,43 @@
 
 import json
 import os
-from typing import Dict, Any
+from datetime import datetime
+from typing import Any, Dict
 
 import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
+
+
+def _convert(obj: Any) -> Any:
+  """Convert common pandas/numpy objects for JSON serialization."""
+  if isinstance(obj, pd.Timestamp):
+    return obj.strftime('%Y-%m-%d')
+  elif isinstance(obj, pd.DataFrame):
+    df = obj.copy()
+    for col in df.columns:
+      if is_datetime64_any_dtype(df[col]):
+        df[col] = df[col].astype(str)
+    return df.to_dict(orient='records')
+  elif isinstance(obj, pd.Series):
+    ser = obj.copy()
+    if is_datetime64_any_dtype(ser):
+      ser = ser.astype(str)
+    return ser.to_dict()
+  elif isinstance(obj, (float, int)) and (pd.isna(obj) or pd.isnull(obj)):
+    return None
+  elif hasattr(obj, 'tolist'):
+    return obj.tolist()
+  else:
+    return obj
+
+
+def _convert_recursive(value: Any) -> Any:
+  """Recursively convert objects to JSON-serialisable forms."""
+  if isinstance(value, dict):
+    return {k: _convert_recursive(v) for k, v in value.items()}
+  if isinstance(value, list):
+    return [_convert_recursive(v) for v in value]
+  return _convert(value)
 
 
 def export_analysis_results(results: Dict[str, Any],
@@ -22,32 +56,7 @@ def export_analysis_results(results: Dict[str, Any],
   os.makedirs(output_dir, exist_ok=True)
 
   # Convert results to JSON-serializable format
-  def convert(obj):
-    if isinstance(obj, pd.Timestamp):
-      return obj.strftime('%Y-%m-%d')
-    elif isinstance(obj, pd.DataFrame):
-      return obj.to_dict(orient='records')
-    elif isinstance(obj, pd.Series):
-      return obj.to_dict()
-    elif isinstance(obj, (float, int)) and (pd.isna(obj) or pd.isnull(obj)):
-      return None
-    elif hasattr(obj, 'tolist'):  # For numpy arrays
-      return obj.tolist()
-    else:
-      return obj
-
-  # Create a copy of results to avoid modifying the original
-  export_results = {}
-
-  # Convert each item in results
-  for key, value in results.items():
-    if isinstance(value, list):
-      export_results[key] = [{k: convert(v) for k, v in item.items()} for item
-        in value] if value else []
-    elif isinstance(value, dict):
-      export_results[key] = {k: convert(v) for k, v in value.items()}
-    else:
-      export_results[key] = convert(value)
+  export_results = _convert_recursive(results)
 
   # Save to JSON file
   symbol = results.get('symbol', '')
@@ -139,3 +148,25 @@ def generate_evolving_daily_ohlc(intraday_df: pd.DataFrame) -> Dict[str, float]:
     ohlc['Volume'] = intraday_df['Volume'].sum()
 
   return ohlc
+
+
+def export_enhanced_results(results: Dict[str, Any],
+    output_dir: str = "output/model_enhanced") -> None:
+  """Export enhanced multi-timeframe results to JSON."""
+  os.makedirs(output_dir, exist_ok=True)
+
+  today = datetime.now().strftime("%d-%m-%Y")
+  symbol = results.get("symbol", "")
+
+  date_dir = os.path.join(output_dir, today)
+  os.makedirs(date_dir, exist_ok=True)
+
+  filename = os.path.join(date_dir,
+                          f"{symbol}_Json_{today.split('-')[0]}{today.split('-')[1]}")
+
+  export_data = _convert_recursive(results)
+
+  with open(filename, 'w') as f:
+    json.dump(export_data, f, indent=2)
+
+  print(f"📝 Enhanced results saved to {filename}")

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,23 @@
+import json
+from datetime import datetime
+
+import pandas as pd
+
+from research_stocks.tools.pattern_analysis.reporting import export_enhanced_results
+
+
+def test_export_enhanced_results_datetime(tmp_path):
+    df = pd.DataFrame({
+        "Datetime": pd.date_range("2024-01-01", periods=2, freq="T"),
+        "Open": [1.0, 2.0],
+        "Close": [1.5, 2.5],
+    })
+    results = {"symbol": "TST", "intraday": df}
+    export_enhanced_results(results, output_dir=str(tmp_path))
+
+    today = datetime.now().strftime("%d-%m-%Y")
+    file_path = tmp_path / today / f"TST_Json_{today.split('-')[0]}{today.split('-')[1]}"
+    with open(file_path) as f:
+        data = json.load(f)
+    assert isinstance(data["intraday"][0]["Datetime"], str)
+


### PR DESCRIPTION
## Summary
- ensure candlestick checks work with small frames and missing volume
- export all values in enhanced results with shared conversion helper
- test datetime handling in enhanced reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce400ea1c832698a37cb677ee4431