### PR TITLE
Improve multi-timeframe forecasting

### DIFF
--- a/research_stocks/src/research_stocks/tools/old_run.py
+++ b/research_stocks/src/research_stocks/tools/old_run.py
@@ -202,7 +202,8 @@ def main() -> None:
     print("\n🔍 Running pattern analysis on earliest data for today…")
 
     # ── 1‑minute pattern scan (20‑bar window, strict filters) ──
-    raw_intraday = analyze_patterns(df_today_min, window=20)["patterns"]
+    raw_intraday = analyze_patterns("", df_today_min, df_today_min,
+                                     window=20, timeframe="1m")["patterns"]
 
     intraday_filtered = [p for p in raw_intraday if
                          p.get("value", 0) >= 1.2 and p.get(
@@ -222,7 +223,8 @@ def main() -> None:
     df_combined = pd.concat([df_hist.tail(180), df_today], ignore_index=True)
 
   # ── Full pattern analysis on daily candles ──
-  results = analyze_patterns(df_combined, window=5)
+  results = analyze_patterns("", df_combined, df_combined, window=5,
+                             timeframe="daily")
 
   # 1️⃣ remove exact structural duplicates
   daily_patterns = drop_duplicates(results["patterns"])

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/forecasting.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/forecasting.py
@@ -150,17 +150,29 @@ def refine_next_predictions(
   vol_lo = close - hi_lo_multiplier_dn * atr
 
   # ── 2.  Pattern-derived bias & confidence ───────────────────────────
+  latest_ts = pd.to_datetime(df.iloc[-1]["Date"])
   recency_cutoff = pd.Timestamp(df.iloc[-10]["Date"])
   pats = [
     p for p in results["patterns"]
     if pd.Timestamp(p["end_date"]) >= recency_cutoff
   ]
 
-  # Weighted counts (use |value| as crude strength; default 1)
-  bull_score = sum((p.get("value", 1) or 1) for p in pats
-                   if p["direction"] == "bullish")
-  bear_score = sum((p.get("value", 1) or 1) for p in pats
-                   if p["direction"] == "bearish")
+  def _decay_weight(p):
+    tf = str(p.get("timeframe", "daily")).lower()
+    if tf.startswith("15"):
+      half_life = 1.0  # hours
+    elif "hour" in tf or tf.startswith("1h"):
+      half_life = 4.0
+    else:
+      half_life = 24.0
+    age = (latest_ts - pd.to_datetime(p["end_date"])).total_seconds() / 3600
+    age = max(age, 0.0)
+    return math.exp(-age / half_life)
+
+  bull_score = sum(_decay_weight(p) * (p.get("value", 1) or 1)
+                   for p in pats if p["direction"] == "bullish")
+  bear_score = sum(_decay_weight(p) * (p.get("value", 1) or 1)
+                   for p in pats if p["direction"] == "bearish")
 
   if bull_score > bear_score:
     pat_dir = "bullish"

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/intraday_factors.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/intraday_factors.py
@@ -240,7 +240,7 @@ def get_confirmed_patterns(symbol: str) -> List[dict]:
   last30 = df.tail(30)
   from research_stocks.tools.pattern_analysis.pattern_analyzer import \
     analyze_patterns  # type: ignore
-  results = analyze_patterns(symbol, last30, last30, window=5)
+  results = analyze_patterns(symbol, last30, last30, window=5, timeframe="daily")
   patterns = []
   cutoff = last30["Date"].iloc[-3]
   for p in results.get("patterns", []):

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/pattern_analyzer.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/pattern_analyzer.py
@@ -146,8 +146,9 @@ def resolve_conflicts(patterns: List[Dict]) -> List[Dict]:
   return [p for i, p in enumerate(sorted_patterns) if keep[i]]
 
 
-def analyze_patterns(symbol: str, df: pd.DataFrame, df_summary: pd.DataFrame, window: int = 5,
-    volume_col: str = None) -> Dict[str, Any]:
+def analyze_patterns(symbol: str, df: pd.DataFrame, df_summary: pd.DataFrame,
+    window: int = 5, volume_col: str | None = None,
+    timeframe: str = "daily") -> Dict[str, Any]:
   """
   Analyze price data for various patterns.
 
@@ -155,6 +156,8 @@ def analyze_patterns(symbol: str, df: pd.DataFrame, df_summary: pd.DataFrame, wi
       df: DataFrame with OHLC data
       window: Window size for pattern detection
       volume_col: Name of volume column if available
+      timeframe: Label for the timeframe of ``df`` (e.g. "daily", "hourly",
+                 "15m").
 
   Returns:
       Dictionary with analysis results
@@ -182,12 +185,15 @@ def analyze_patterns(symbol: str, df: pd.DataFrame, df_summary: pd.DataFrame, wi
                             'Bearish Harami']:
           direction = 'bearish'
 
-        pattern = {'pattern': pattern_name,
-          'start_date': df.iloc[max(0, i - 2)]['Date'],
-          # Start a few bars before
-          'end_date': df.iloc[i]['Date'], 'direction': direction, 'value': 1.0,
-          # Default value, will be refined
-          'status': 'Confirmed'}
+        pattern = {
+          'pattern': pattern_name,
+          'start_date': df.iloc[max(0, i - 2)]['Date'],  # Start a few bars before
+          'end_date': df.iloc[i]['Date'],
+          'direction': direction,
+          'value': 1.0,  # Default value, will be refined
+          'status': 'Confirmed',
+          'timeframe': timeframe,
+        }
 
         # Calculate pattern height
         if i > 0:
@@ -208,6 +214,7 @@ def analyze_patterns(symbol: str, df: pd.DataFrame, df_summary: pd.DataFrame, wi
   # Calculate scores for chart patterns
   for pattern in chart_patterns:
     pattern['value'] = calculate_pattern_score(pattern, df, volume_col)
+    pattern['timeframe'] = timeframe
 
   # Add chart patterns to results
   results['patterns'].extend(chart_patterns)

--- a/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
+++ b/research_stocks/src/research_stocks/tools/pattern_analysis/reporting.py
@@ -40,9 +40,19 @@ def export_analysis_results(results: Dict[str, Any],
   # Create a copy of results to avoid modifying the original
   export_results = {}
 
+  def _label(p_list: Any) -> None:
+    if not isinstance(p_list, list):
+      return
+    for p in p_list:
+      tf = p.get("timeframe")
+      name = p.get("pattern")
+      if tf and name:
+        p["pattern"] = f"{tf}: {name}"
+
   # Convert each item in results
   for key, value in results.items():
     if isinstance(value, list):
+      _label(value)
       export_results[key] = [{k: convert(v) for k, v in item.items()} for item
         in value] if value else []
     elif isinstance(value, dict):
@@ -87,6 +97,19 @@ def export_enhanced_results(results: Dict[str, Any], output_dir: str = "output/m
     return obj
 
   serializable = json.loads(json.dumps(results, default=convert))
+
+  def _label_patterns(p_list: Any) -> None:
+    if not isinstance(p_list, list):
+      return
+    for p in p_list:
+      tf = p.get("timeframe")
+      name = p.get("pattern")
+      if tf and name:
+        p["pattern"] = f"{tf}: {name}"
+
+  for key in ["patterns", "hourly_patterns", "minutes_patterns"]:
+    if key in serializable:
+      _label_patterns(serializable[key])
 
   filename = os.path.join(date_dir, f"{symbol}_Json_{today.split('-')[0]}{today.split('-')[1]}.json")
   with open(filename, 'w') as f:

--- a/research_stocks/src/research_stocks/tools/run_analysis.py
+++ b/research_stocks/src/research_stocks/tools/run_analysis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from datetime import datetime
 
 import pandas as pd
 
@@ -81,7 +82,8 @@ def main(symbol: str = "NVDA") -> None:
   # ── Daily analysis ───────────────────────────────────────────────────
   df_combined = df_daily_hist.tail(180)
   df_summary = df_combined.tail(30)
-  results = analyze_patterns(symbol, df_combined, df_summary, window=5)
+  results = analyze_patterns(symbol, df_combined, df_summary,
+                             window=5, timeframe="daily")
   daily_patterns = cluster_and_keep_best(
       remove_duplicates_by_status(drop_duplicates(results["patterns"]),
           status_to_remove="Duplicate"), overlap=0.7)
@@ -89,7 +91,9 @@ def main(symbol: str = "NVDA") -> None:
   results = refine_next_predictions(results, df_combined)
   export_analysis_results(results)
   # ── Hourly analysis ──────────────────────────────────────────────────
-  hourly_results = analyze_patterns(symbol, df_hourly_hist, df_hourly_hist.tail(48), window=12)
+  hourly_results = analyze_patterns(symbol, df_hourly_hist,
+                                    df_hourly_hist.tail(48), window=12,
+                                    timeframe="hourly")
   hourly_patterns = cluster_and_keep_best(
       remove_duplicates_by_status(drop_duplicates(hourly_results["patterns"]),
           status_to_remove="Duplicate"), overlap=0.7)
@@ -99,11 +103,21 @@ def main(symbol: str = "NVDA") -> None:
 
   # ── 15-minute analysis ───────────────────────────────────────────────
   if not df_minutes.empty:
-    minutes_results = analyze_patterns(symbol, df_minutes, df_minutes.tail(48), window=16)
+    minutes_results = analyze_patterns(symbol, df_minutes,
+                                       df_minutes.tail(48), window=16,
+                                       timeframe="15m")
+    today_str = datetime.now().strftime("%Y-%m-%d")
+    start_day = pd.to_datetime(f"{today_str} 09:30")
+    cutoff = start_day + pd.Timedelta(hours=3)
+    df_today = df_minutes[df_minutes["Date"].str.startswith(today_str)]
+    df_first3h = df_today[pd.to_datetime(df_today["Date"]) <= cutoff]
     minutes_patterns = cluster_and_keep_best(
         remove_duplicates_by_status(drop_duplicates(minutes_results["patterns"]),
             status_to_remove="Duplicate"), overlap=0.7)
-    minutes_results["patterns"] = minutes_patterns
+    minutes_results["patterns"] = [
+        p for p in minutes_patterns
+        if start_day <= pd.to_datetime(p["end_date"]) <= cutoff
+    ]
     minutes_results = refine_next_predictions(minutes_results, df_minutes,
                                               weight_pattern=0.6, weight_volatility=0.4)
   else:
@@ -126,7 +140,7 @@ def main(symbol: str = "NVDA") -> None:
 
   if not df_minutes.empty:
     minute_fcast = probabilistic_timeframe_forecast(
-        ohlc_df=df_minutes,
+        ohlc_df=df_first3h if not df_first3h.empty else df_minutes,
         active_patterns=minutes_results["patterns"],
         num_mc_paths=mc_paths,
         beta_k=0.6,


### PR DESCRIPTION
## Summary
- label patterns with their timeframe
- decay pattern influence in `refine_next_predictions`
- filter 15m patterns to the first three hours of the day
- emit timeframe labels in exported JSON
- wire up new `timeframe` param across tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf57722e083268fb0aec683b20beb